### PR TITLE
update files to Smack 4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,6 @@ mainClassName = 'eu.geekplace.xmpp.testclient.Test'
 applicationDefaultJvmArgs = ["-ea"]
 
 repositories {
-	mavenLocal()
-	maven {
-		url 'https://oss.sonatype.org/content/repositories/snapshots'
-	}
 	mavenCentral()
 }
 
@@ -22,7 +18,7 @@ configurations.all {
 }
 
 ext {
-	smackVersion='4.1.0-rc3-SNAPSHOT'
+	smackVersion='4.1.0'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ mainClassName = 'eu.geekplace.xmpp.testclient.Test'
 applicationDefaultJvmArgs = ["-ea"]
 
 repositories {
+	mavenLocal()
+	maven {
+		url 'https://oss.sonatype.org/content/repositories/snapshots'
+	}
 	mavenCentral()
 }
 
@@ -18,7 +22,7 @@ configurations.all {
 }
 
 ext {
-	smackVersion='4.1.0'
+	smackVersion='4.1.1'
 }
 
 dependencies {


### PR DESCRIPTION
I needed to test Smack 4.1 stream management stream resumption and I've updated the gradle file to Smack 4.1 leaving only MavenCentral, because the file was out of date (rc3)
